### PR TITLE
refactor: change file permissions of theme/

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
       - 3306
       - 33060
   wordpress:
+    user: 1000:1000
     image: wordpress:latest
     volumes:
       - wp_data:/var/www/html


### PR DESCRIPTION
Motivation
----------
This will ensure that UNIX file permissions of the created volume `/themes` will be the default user and the default group of the host machine.

Thus, no more access restrictions when editing the files in that folder on the host.

See: https://stackoverflow.com/a/56844765
User with GID 1000 is apparently the first non-system user on a UNIX system: https://www.redhat.com/sysadmin/user-account-gid-uid

How to test
-----------
1. `docker-compose down -v`
2. `rm -rf themes`
3. `docker-compose up`
4. `ls -lla`
5. Folder `./themes` should have the same file permissions as all the other folders